### PR TITLE
タイマーの通知設定の不具合を修正

### DIFF
--- a/IterationTimer/Main.swift
+++ b/IterationTimer/Main.swift
@@ -11,7 +11,6 @@ import WidgetKit
 
 @main
 struct Main: App {
-    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         FirebaseApp.configure()
@@ -20,11 +19,6 @@ struct Main: App {
     var body: some Scene {
         WindowGroup {
             TimerListsView()
-        }
-        .onChange(of: scenePhase) { phase in
-            if phase == .active {
-                WidgetCenter.shared.reloadAllTimelines()
-            }
         }
     }
 }

--- a/IterationTimer/ViewModel/TimerEditViewModel.swift
+++ b/IterationTimer/ViewModel/TimerEditViewModel.swift
@@ -56,7 +56,7 @@ class TimerEditViewModel: ObservableObject {
         self.mode = mode
 
         UNUserNotificationCenter.current().getNotificationSettings {
-            self.isEnableNotification = $0.notificationCenterSetting == .enabled
+            self.isEnableNotification = $0.authorizationStatus != .denied
         }
         
         let timer = $input.map(IterationTimer.init)

--- a/IterationTimer/ViewModel/TimerListsViewModel.swift
+++ b/IterationTimer/ViewModel/TimerListsViewModel.swift
@@ -31,7 +31,9 @@ class TimerListsViewModel: ObservableObject {
             .store(in: &cancellables)
 
         $timers
-            .map { $0.map { _ in false } }
+            .map(\.count)
+            .removeDuplicates()
+            .map { [Bool](repeating: false, count: $0) }
             .assign(to: \.isTransitionEditTimer, on: self)
             .store(in: &cancellables)
     }

--- a/IterationTimer/Views/TimerListsView.swift
+++ b/IterationTimer/Views/TimerListsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import IterationTimerUI
 import IterationTimerModel
+import WidgetKit
 
 struct TimerListsView: View {
     
@@ -42,6 +43,9 @@ struct TimerListsView: View {
         .navigationViewStyle(StackNavigationViewStyle())
         .sheet(isPresented: $viewModel.isTransitionAddTimer, onDismiss: viewModel.refreshTimers) {
             TimerEditView(mode: .add)
+        }
+        .onAppear {
+            WidgetCenter.shared.reloadAllTimelines()
         }
     }
 }


### PR DESCRIPTION
## 概要
- タイマーの通知設定が行えない不具合を修正
- タイマーの通知設定時に編集中のタイマーが閉じてしまう不具合を修正

## 説明
- タイマー編集画面におけるピッカーの有効条件を見直し
- MainにscenePhaseのonChangeを適用すると、バックグラウンド時、通知のアラート時にViewが再生成される。画面のpresent状況もリセットされるので、表示しているタイマー編集画面が閉じてしまう
