### PR TITLE
タイマーの保持をiCloudとAppGroupsを同時に使うように修正

### DIFF
--- a/IterationTimer/IterationTimer.entitlements
+++ b/IterationTimer/IterationTimer.entitlements
@@ -7,6 +7,8 @@
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
-	<string>group.IterationTimer.timers</string>
+	<array>
+		<string>group.IterationTimer.timers</string>
+	</array>
 </dict>
 </plist>

--- a/IterationTimer/Views/TimerEditView.swift
+++ b/IterationTimer/Views/TimerEditView.swift
@@ -37,7 +37,7 @@ struct TimerEditView: View {
     
     public init(mode: Mode) {
         self.mode = mode
-        self.viewModel = TimerEditViewModel(repository: IterationTimerRepository(dataStore: NSUbiquitousKeyValueStore.default), mode: mode)
+        self.viewModel = TimerEditViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.standard, remote: NSUbiquitousKeyValueStore.default)), mode: mode)
     }
 
     var body: some View {

--- a/IterationTimer/Views/TimerEditView.swift
+++ b/IterationTimer/Views/TimerEditView.swift
@@ -37,7 +37,7 @@ struct TimerEditView: View {
     
     public init(mode: Mode) {
         self.mode = mode
-        self.viewModel = TimerEditViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.standard, remote: NSUbiquitousKeyValueStore.default)), mode: mode)
+        self.viewModel = TimerEditViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.appGroups, remote: NSUbiquitousKeyValueStore.default)), mode: mode)
     }
 
     var body: some View {

--- a/IterationTimer/Views/TimerListsView.swift
+++ b/IterationTimer/Views/TimerListsView.swift
@@ -12,7 +12,7 @@ import WidgetKit
 
 struct TimerListsView: View {
     
-    @ObservedObject var viewModel = TimerListsViewModel(repository: IterationTimerRepository(dataStore: NSUbiquitousKeyValueStore.default))
+    @ObservedObject var viewModel = TimerListsViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.standard, remote: NSUbiquitousKeyValueStore.default)))
     
     var body: some View {
         NavigationView {

--- a/IterationTimer/Views/TimerListsView.swift
+++ b/IterationTimer/Views/TimerListsView.swift
@@ -12,7 +12,7 @@ import WidgetKit
 
 struct TimerListsView: View {
     
-    @ObservedObject var viewModel = TimerListsViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.standard, remote: NSUbiquitousKeyValueStore.default)))
+    @ObservedObject var viewModel = TimerListsViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.appGroups, remote: NSUbiquitousKeyValueStore.default)))
     
     var body: some View {
         NavigationView {

--- a/IterationTimerModel/Repository/DataStoreKey.swift
+++ b/IterationTimerModel/Repository/DataStoreKey.swift
@@ -1,5 +1,5 @@
 //
-//  UserDefaultsKey.swift
+//  DataStoreKey.swift
 //  IterationTimer
 //
 //  Created by hal1437 on 2021/04/27.
@@ -7,6 +7,7 @@
 
 import Foundation
 
-enum UserDefaultsKey: String {
+enum DataStoreKey: String, CaseIterable {
     case iterationTimer
+    case updateDate
 }

--- a/IterationTimerModel/Repository/IterationTimerRepository.swift
+++ b/IterationTimerModel/Repository/IterationTimerRepository.swift
@@ -23,7 +23,7 @@ public struct IterationTimerRepository: IterationTimerRepositoryProtocol {
     }
 
     public var getTimers: [IterationTimer] {
-        guard let json = dataStore.get(forKey: UserDefaultsKey.iterationTimer.rawValue),
+        guard let json = dataStore.get(forKey: DataStoreKey.iterationTimer.rawValue),
               let data = json.data(using: .utf8),
               let array = try? JSONDecoder().decode([IterationTimer].self, from: data) else { return [] }
         
@@ -48,6 +48,6 @@ public struct IterationTimerRepository: IterationTimerRepositoryProtocol {
         let json = try! JSONEncoder().encode(array)
         let string = String(data: json, encoding: .utf8)!
         
-        dataStore.set(value: string, forKey: UserDefaultsKey.iterationTimer.rawValue)
+        dataStore.set(value: string, forKey: DataStoreKey.iterationTimer.rawValue)
     }
 }

--- a/IterationTimerModel/Repository/UserDefaultsICloudSynchronizer.swift
+++ b/IterationTimerModel/Repository/UserDefaultsICloudSynchronizer.swift
@@ -1,0 +1,67 @@
+//
+//  DataStoreSynchronizer.swift
+//  IterationTimerCore
+//
+//  Created by hal1437 on 2021/11/28.
+//
+
+import Foundation
+import IterationTimerCore
+
+// 2つのDataStoreを同期しながら使用できるDataStore
+public class DataStoreSynchronizer: DataStore {
+    
+    let local: DataStore
+    let remote: DataStore
+    var currentDateStrategy = { Date() }
+
+    var dataStore: DataStore {
+        return isRequireDownload ? remote : local
+    }
+
+    var isRequireDownload: Bool {
+        // リモートとローカルのどちらにも updateDate が存在しない場合はリモートを利用する
+        guard let localDate  = TimeInterval(local .get(forKey: DataStoreKey.updateDate.rawValue) ?? "0"),
+              let remoteDate = TimeInterval(remote.get(forKey: DataStoreKey.updateDate.rawValue) ?? "0"),
+              !(localDate == 0 && remoteDate == 0) else { return true }
+        
+        return localDate < remoteDate
+    }
+    
+    public init(local: DataStore, remote: DataStore) {
+        self.local = local
+        self.remote = remote
+    }
+    
+    public func `get`(forKey: String) -> String? {
+        if isRequireDownload {
+             download()
+        }
+        return dataStore.get(forKey: forKey)
+    }
+    
+    public func `set`(value: String?, forKey: String) {
+        if isRequireDownload {
+             download()
+        }
+        local.set(value: String(Int64(currentDateStrategy().timeIntervalSince1970)), forKey: DataStoreKey.updateDate.rawValue)
+        local.set(value: value, forKey: forKey)
+        upload()
+    }
+    
+    // UserDefaults -> iCloud
+    private func upload() {
+        copyData(from: local, to: remote)
+    }
+    
+    // iCloud -> UserDefaults
+    private func download() {
+        copyData(from: remote, to: local)
+    }
+    
+    private func copyData(from: DataStore, to: DataStore) {
+        DataStoreKey.allCases.forEach {
+            to.set(value: from.get(forKey: $0.rawValue), forKey: $0.rawValue)
+        }
+    }
+}

--- a/IterationTimerWidget/IterationTimerWidget.entitlements
+++ b/IterationTimerWidget/IterationTimerWidget.entitlements
@@ -5,6 +5,8 @@
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)com.hal1437.IterationTimer</string>
 	<key>com.apple.security.application-groups</key>
-	<string>group.IterationTimer.timers</string>
+	<array>
+		<string>group.IterationTimer.timers</string>
+	</array>
 </dict>
 </plist>

--- a/IterationTimerWidget/UI/MultipleTimer.swift
+++ b/IterationTimerWidget/UI/MultipleTimer.swift
@@ -12,7 +12,7 @@ import IterationTimerUI
 
 struct MultipleTimer: View {
     @Environment(\.widgetFamily) var family
-    @ObservedObject var viewModel = MultipleTimerViewModel(repository: IterationTimerRepository(dataStore: NSUbiquitousKeyValueStore.default))
+    @ObservedObject var viewModel = MultipleTimerViewModel(repository: IterationTimerRepository(dataStore: DataStoreSynchronizer(local: UserDefaults.appGroups, remote: NSUbiquitousKeyValueStore.default)))
     private let drawable = Drawable()
     
     var body: some View {

--- a/Test/IterationTimerModelTests/Mock/MockDataStore.swift
+++ b/Test/IterationTimerModelTests/Mock/MockDataStore.swift
@@ -1,0 +1,22 @@
+//
+//  MockDataStore.swift
+//  IterationTimerModelTests
+//
+//  Created by hal1437 on 2021/11/28.
+//
+
+import Foundation
+@testable import IterationTimerModel
+
+class MockDataStore: DataStore {
+    var onGet: ((String) -> String?)?
+    var onSet: ((String?, String) -> Void)?
+    
+    func `get`(forKey: String) -> String? {
+        return onGet?(forKey)
+    }
+    
+    func `set`(value: String?, forKey: String) {
+        onSet?(value, forKey)
+    }
+}

--- a/Test/IterationTimerModelTests/Repository/DataStoreSynchronizerTest.swift
+++ b/Test/IterationTimerModelTests/Repository/DataStoreSynchronizerTest.swift
@@ -1,0 +1,108 @@
+//
+//  DataStoreSynchronizerTest.swift
+//  IterationTimerModelTests
+//
+//  Created by hal1437 on 2021/11/28.
+//
+
+import XCTest
+@testable import IterationTimerModel
+
+class DataStoreSynchronizerTest: XCTestCase {
+
+    func testMigration() throws {
+        let local = SynchronizerMockDataStore(initial: [.updateDate: nil, .iterationTimer: "local"])
+        let remote = SynchronizerMockDataStore(initial: [.updateDate: nil, .iterationTimer: "remote"])
+        
+        let sync = DataStoreSynchronizer(local: local, remote: remote)
+        
+        XCTAssertEqual(sync.get(forKey: DataStoreKey.iterationTimer.rawValue), "remote",
+                       "2つのタイマーのIntervalが0の場合はremoteを優先する。")
+    }
+
+    func testGetLocal() throws {
+        let local = SynchronizerMockDataStore(initial: [.updateDate: "2", .iterationTimer: "local"])
+        let remote = SynchronizerMockDataStore(initial: [.updateDate: "1", .iterationTimer: "remote"])
+        
+        let sync = DataStoreSynchronizer(local: local, remote: remote)
+        
+        XCTAssertEqual(sync.get(forKey: DataStoreKey.iterationTimer.rawValue), "local",
+                       "新しい方を使用する")
+        XCTAssertEqual(local .result[.iterationTimer]!.latest, nil, "変化していないこと")
+        XCTAssertEqual(local .result[.updateDate]!.latest    , nil, "変化していないこと")
+        XCTAssertEqual(remote.result[.iterationTimer]!.latest, nil, "変化していないこと")
+        XCTAssertEqual(remote.result[.updateDate]!.latest    , nil, "変化していないこと")
+    }
+
+    func testGetRemote() throws {
+        let local = SynchronizerMockDataStore(initial: [.updateDate: "1", .iterationTimer: "local"])
+        let remote = SynchronizerMockDataStore(initial: [.updateDate: "2", .iterationTimer: "remote"])
+        
+        let sync = DataStoreSynchronizer(local: local, remote: remote)
+        
+        XCTAssertEqual(sync.get(forKey: DataStoreKey.iterationTimer.rawValue), "remote",
+                       "新しい方を使用する")
+        XCTAssertEqual(local .result[.iterationTimer]!.latest, "remote", "新しい方で上書きされていること")
+        XCTAssertEqual(local .result[.updateDate]!.latest    , "2"     , "新しい方で上書きされていること")
+        XCTAssertEqual(remote.result[.iterationTimer]!.latest, nil, "変化していないこと")
+        XCTAssertEqual(remote.result[.updateDate]!.latest    , nil, "変化していないこと")
+    }
+
+    func testSetLocalNewer() throws {
+        let local = SynchronizerMockDataStore(initial: [.updateDate: "2", .iterationTimer: "local"])
+        let remote = SynchronizerMockDataStore(initial: [.updateDate: "1", .iterationTimer: "remote"])
+        
+        let sync = DataStoreSynchronizer(local: local, remote: remote)
+        
+        sync.currentDateStrategy = { Date(timeIntervalSince1970: 3) }
+        sync.set(value: "new", forKey: DataStoreKey.iterationTimer.rawValue)
+
+        XCTAssertEqual(local .result[.iterationTimer]!.latest, "new", "新しい値で上書きされていること")
+        XCTAssertEqual(local .result[.updateDate]!.latest    , "3"  , "新しい値で上書きされていること")
+        XCTAssertEqual(remote.result[.iterationTimer]!.latest, "new", "新しい値で上書きされていること")
+        XCTAssertEqual(remote.result[.updateDate]!.latest    , "3"  , "新しい値で上書きされていること")
+        // 現状はiterationTimerしかKeyが無いが、今後増えた場合は以下のテストを有効化する。
+//        XCTAssertEqual(local.result[<#newProperty#>]!.latest, remote.result[<#newProperty#>]!.latest, "setに関係のない値でもLocalの方が新しければuploadされていること")
+    }
+
+    func testGetRemoteNewer() throws {
+        let local = SynchronizerMockDataStore(initial: [.updateDate: "1", .iterationTimer: "local"])
+        let remote = SynchronizerMockDataStore(initial: [.updateDate: "2", .iterationTimer: "remote"])
+
+        let sync = DataStoreSynchronizer(local: local, remote: remote)
+        
+        sync.currentDateStrategy = { Date(timeIntervalSince1970: 3) }
+        sync.set(value: "new", forKey: DataStoreKey.iterationTimer.rawValue)
+
+        XCTAssertEqual(local .result[.iterationTimer]!.latest, "new", "新しい値で上書きされていること")
+        XCTAssertEqual(local .result[.updateDate]!.latest    , "3"  , "新しい値で上書きされていること")
+        XCTAssertEqual(remote.result[.iterationTimer]!.latest, "new", "新しい値で上書きされていること")
+        XCTAssertEqual(remote.result[.updateDate]!.latest    , "3"  , "新しい値で上書きされていること")
+        // 現状はiterationTimerしかKeyが無いが、今後増えた場合は以下のテストを有効化する。
+//        XCTAssertEqual(remote.result[<#newProperty#>]!.latest, .result[<#newProperty#>]!.latest, "setに関係のない値でもRemoteの方が新しければdownloadされていること")
+    }
+}
+
+class SynchronizerMockDataStore: MockDataStore {
+    var result: [DataStoreKey: (initial: String?, latest: String?)]
+    
+    init(initial: [DataStoreKey: String?]) {
+        
+        var result = [DataStoreKey: (initial: String?, latest: String?)]()
+        DataStoreKey.allCases.forEach {
+            result[$0] = (initial: initial[$0]!, latest: nil)
+        }
+        self.result = result
+        
+        super.init()
+
+        self.onGet = { forKey in
+            let key = DataStoreKey(rawValue: forKey)!
+            return self.result[key]!.latest ?? self.result[key]?.initial
+        }
+        self.onSet = { (value, forKey) in
+            let key = DataStoreKey(rawValue: forKey)!
+            self.result[key]!.latest = value
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -31,10 +31,12 @@ targets:
       configs:
         debug:
           CODE_SIGN_IDENTITY: Apple Development
+          CODE_SIGN_ENTITLEMENTS: IterationTimer/IterationTimer.entitlements
           PROVISIONING_PROFILE_SPECIFIER: com.hal1437.IterationTimer
           DEVELOPMENT_TEAM: JTT4T82QAY
         release:
           CODE_SIGN_IDENTITY: iPhone Distribution
+          CODE_SIGN_ENTITLEMENTS: IterationTimer/IterationTimer.entitlements
           PROVISIONING_PROFILE_SPECIFIER: match AppStore com.hal1437.IterationTimer
           DEVELOPMENT_TEAM: JTT4T82QAY
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -59,7 +61,7 @@ targets:
     entitlements:
       path: IterationTimer/IterationTimer.entitlements
       properties:
-        com.apple.security.application-groups: group.IterationTimer.timers
+        com.apple.security.application-groups: [group.IterationTimer.timers]
         aps-environment: development
         com.apple.developer.ubiquity-kvstore-identifier: $(TeamIdentifierPrefix)$(CFBundleIdentifier)
     preBuildScripts:
@@ -131,7 +133,7 @@ targets:
     entitlements:
       path: IterationTimerWidget/IterationTimerWidget.entitlements
       properties:
-        com.apple.security.application-groups: group.IterationTimer.timers
+        com.apple.security.application-groups: [group.IterationTimer.timers]
         com.apple.developer.ubiquity-kvstore-identifier: $(TeamIdentifierPrefix)com.hal1437.IterationTimer
     preBuildScripts:
       - name: Set app build version


### PR DESCRIPTION
DataStoreSynchronizerを作成。このクラスは2つのDataStoreの最終更新時刻を参照し新しい方を採用する。また、タイマーが更新された場合はiCloudとAppGroupsの両方を更新する。

これによってExtensionであるWidgetへの連携が速くなり、ウィジェットの更新時間の問題も解消する。
resolved #8 